### PR TITLE
update-all: Remove the space after the slash for appending TZ

### DIFF
--- a/update-all
+++ b/update-all
@@ -22,5 +22,5 @@ cd /srv/www.das-labor.org/bin/
 ./update-ics-rss-htmlsnippet.rb > /dev/null
 
 # append timezone after calendar description
-sed -e '/X-WR-CALDESC/ a X-WR-TIMEZONE:Europe/Berlin' -i \
+sed -e '/X-WR-CALDESC/a X-WR-TIMEZONE:Europe/Berlin' -i \
   /srv/www.das-labor.org/htdoc/termine.ics


### PR DESCRIPTION
see https://fabianlee.org/2018/10/28/linux-using-sed-to-insert-lines-before-or-after-a-match/ for a similar example